### PR TITLE
Add volume expansion

### DIFF
--- a/pkg/cloud/fakes.go
+++ b/pkg/cloud/fakes.go
@@ -74,19 +74,29 @@ func (c *FakeCloudProvider) CreateFileSystem(ctx context.Context, volumeName str
 	return fs, nil
 }
 
-func (c *FakeCloudProvider) DeleteFileSystem(ctx context.Context, volumeID string) error {
-	delete(c.fileSystems, volumeID)
+func (c *FakeCloudProvider) ResizeFileSystem(ctx context.Context, fileSystemId string, newSizeGiB int64) (*int64, error) {
+	for _, fs := range c.fileSystems {
+		if fs.FileSystemId == fileSystemId {
+			fs.StorageCapacity = newSizeGiB
+			return &newSizeGiB, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (c *FakeCloudProvider) DeleteFileSystem(ctx context.Context, filesystemId string) error {
+	delete(c.fileSystems, filesystemId)
 	for name, fs := range c.fileSystems {
-		if fs.FileSystemId == volumeID {
+		if fs.FileSystemId == filesystemId {
 			delete(c.fileSystems, name)
 		}
 	}
 	return nil
 }
 
-func (c *FakeCloudProvider) DescribeFileSystem(ctx context.Context, volumeID string) (*FileSystem, error) {
+func (c *FakeCloudProvider) DescribeFileSystem(ctx context.Context, filesystemId string) (*FileSystem, error) {
 	for _, fs := range c.fileSystems {
-		if fs.FileSystemId == volumeID {
+		if fs.FileSystemId == filesystemId {
 			return fs, nil
 		}
 	}
@@ -94,6 +104,10 @@ func (c *FakeCloudProvider) DescribeFileSystem(ctx context.Context, volumeID str
 }
 
 func (c *FakeCloudProvider) WaitForFileSystemAvailable(ctx context.Context, fileSystemId string) error {
+	return nil
+}
+
+func (c *FakeCloudProvider) WaitForFileSystemResize(ctx context.Context, fileSystemId string, newSizeGiB int64) error {
 	return nil
 }
 
@@ -125,19 +139,30 @@ func (c *FakeCloudProvider) CreateVolume(ctx context.Context, volumeName string,
 	return v, nil
 }
 
-func (c *FakeCloudProvider) DeleteVolume(ctx context.Context, volumeID string) (err error) {
-	delete(c.volumes, volumeID)
+func (c *FakeCloudProvider) ResizeVolume(ctx context.Context, volumeId string, newSizeGiB int64) (*int64, error) {
+	for _, v := range c.volumes {
+		if v.VolumeId == volumeId {
+			v.StorageCapacityQuotaGiB = newSizeGiB
+			v.StorageCapacityReservationGiB = newSizeGiB
+			return &newSizeGiB, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (c *FakeCloudProvider) DeleteVolume(ctx context.Context, volumeId string) (err error) {
+	delete(c.volumes, volumeId)
 	for name, v := range c.volumes {
-		if v.VolumeId == volumeID {
+		if v.VolumeId == volumeId {
 			delete(c.volumes, name)
 		}
 	}
 	return nil
 }
 
-func (c *FakeCloudProvider) DescribeVolume(ctx context.Context, volumeID string) (*Volume, error) {
+func (c *FakeCloudProvider) DescribeVolume(ctx context.Context, volumeId string) (*Volume, error) {
 	for _, v := range c.volumes {
-		if v.VolumeId == volumeID {
+		if v.VolumeId == volumeId {
 			return v, nil
 		}
 	}
@@ -145,6 +170,10 @@ func (c *FakeCloudProvider) DescribeVolume(ctx context.Context, volumeID string)
 }
 
 func (c *FakeCloudProvider) WaitForVolumeAvailable(ctx context.Context, volumeId string) error {
+	return nil
+}
+
+func (c *FakeCloudProvider) WaitForVolumeResize(ctx context.Context, volumeId string, newSizeGiB int64) error {
 	return nil
 }
 
@@ -180,9 +209,9 @@ func (c *FakeCloudProvider) DeleteSnapshot(ctx context.Context, snapshotId strin
 	return nil
 }
 
-func (c *FakeCloudProvider) DescribeSnapshot(ctx context.Context, snapshotID string) (*Snapshot, error) {
+func (c *FakeCloudProvider) DescribeSnapshot(ctx context.Context, snapshotId string) (*Snapshot, error) {
 	for _, s := range c.snapshots {
-		if s.SnapshotID == snapshotID {
+		if s.SnapshotID == snapshotId {
 			return s, nil
 		}
 	}

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -84,6 +84,7 @@ func TestCreateVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -162,6 +163,7 @@ func TestCreateVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -242,6 +244,7 @@ func TestCreateVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -336,6 +339,7 @@ func TestCreateVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -380,6 +384,7 @@ func TestCreateVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -427,6 +432,7 @@ func TestCreateVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -475,6 +481,7 @@ func TestCreateVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -529,6 +536,7 @@ func TestCreateVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -571,6 +579,7 @@ func TestCreateVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -621,6 +630,7 @@ func TestCreateVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -672,6 +682,7 @@ func TestCreateVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -725,6 +736,7 @@ func TestCreateVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -771,6 +783,7 @@ func TestCreateVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -819,6 +832,7 @@ func TestDeleteVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -845,6 +859,7 @@ func TestDeleteVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -871,6 +886,7 @@ func TestDeleteVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -897,6 +913,7 @@ func TestDeleteVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -923,6 +940,7 @@ func TestDeleteVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -949,6 +967,7 @@ func TestDeleteVolume(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -981,6 +1000,7 @@ func TestControllerGetCapabilities(t *testing.T) {
 
 	driver := &Driver{
 		endpoint: endpoint,
+		inFlight: internal.NewInFlight(),
 		cloud:    mockCloud,
 	}
 
@@ -1017,6 +1037,7 @@ func TestValidateVolumeCapabilities(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -1053,6 +1074,7 @@ func TestValidateVolumeCapabilities(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -1089,6 +1111,7 @@ func TestValidateVolumeCapabilities(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -1115,6 +1138,7 @@ func TestValidateVolumeCapabilities(t *testing.T) {
 
 				driver := &Driver{
 					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
 					cloud:    mockCloud,
 				}
 
@@ -1377,6 +1401,348 @@ func TestDeleteSnapshot(t *testing.T) {
 				_, err := driver.DeleteSnapshot(ctx, req)
 				if err == nil {
 					t.Fatalf("DeleteSnapshot is not failed: %v", err)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.testFunc)
+	}
+}
+
+func TestControllerExpandVolume(t *testing.T) {
+	var (
+		dnsName               = "dnsName"
+		endpoint              = "endpoint"
+		filesystemId          = "fs-1234"
+		volumeId              = "fsvol-1234"
+		storageCapacity int64 = 100
+		currentBytes          = util.GiBToBytes(storageCapacity)
+		newCapacity     int64 = 150
+		requiredBytes         = util.GiBToBytes(newCapacity)
+		limitBytes            = util.GiBToBytes(newCapacity)
+		volumePath            = "/"
+	)
+	testCases := []struct {
+		name     string
+		testFunc func(t *testing.T)
+	}{
+		{
+			name: "success: filesystem",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
+					cloud:    mockCloud,
+				}
+
+				req := &csi.ControllerExpandVolumeRequest{
+					VolumeId: filesystemId,
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: requiredBytes,
+						LimitBytes:    limitBytes,
+					},
+				}
+				filesystem := &cloud.FileSystem{
+					DnsName:         dnsName,
+					FileSystemId:    filesystemId,
+					StorageCapacity: storageCapacity,
+				}
+
+				ctx := context.Background()
+				mockCloud.EXPECT().DescribeFileSystem(gomock.Eq(ctx), gomock.Eq(filesystemId)).Return(filesystem, nil)
+				mockCloud.EXPECT().ResizeFileSystem(gomock.Eq(ctx), gomock.Eq(filesystemId), gomock.Any()).Return(&newCapacity, nil)
+				mockCloud.EXPECT().WaitForFileSystemResize(gomock.Eq(ctx), gomock.Eq(filesystemId), newCapacity).Return(nil)
+
+				resp, err := driver.ControllerExpandVolume(ctx, req)
+				if err != nil {
+					t.Fatalf("ControllerExpandVolume failed: %v", err)
+				}
+
+				if resp.CapacityBytes != requiredBytes {
+					t.Fatal("resp.CapacityBytes is not equal to requiredBytes")
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "success: volume",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
+					cloud:    mockCloud,
+				}
+
+				req := &csi.ControllerExpandVolumeRequest{
+					VolumeId: volumeId,
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: requiredBytes,
+						LimitBytes:    limitBytes,
+					},
+				}
+				volume := &cloud.Volume{
+					FileSystemId:                  filesystemId,
+					VolumeId:                      volumeId,
+					StorageCapacityQuotaGiB:       storageCapacity,
+					StorageCapacityReservationGiB: storageCapacity,
+					VolumePath:                    volumePath,
+				}
+
+				ctx := context.Background()
+				mockCloud.EXPECT().DescribeVolume(gomock.Eq(ctx), gomock.Eq(volumeId)).Return(volume, nil)
+				mockCloud.EXPECT().ResizeVolume(gomock.Eq(ctx), gomock.Eq(volumeId), gomock.Any()).Return(&newCapacity, nil)
+				mockCloud.EXPECT().WaitForVolumeResize(gomock.Eq(ctx), gomock.Eq(volumeId), newCapacity).Return(nil)
+
+				resp, err := driver.ControllerExpandVolume(ctx, req)
+				if err != nil {
+					t.Fatalf("ControllerExpandVolume failed: %v", err)
+				}
+
+				if resp.CapacityBytes != requiredBytes {
+					t.Fatal("resp.CapacityBytes is not equal to requiredBytes")
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "success: newCapacity less than currentCapacity",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+				var lowerBytes int64 = 1
+
+				driver := &Driver{
+					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
+					cloud:    mockCloud,
+				}
+
+				req := &csi.ControllerExpandVolumeRequest{
+					VolumeId: filesystemId,
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: lowerBytes,
+						LimitBytes:    limitBytes,
+					},
+				}
+				filesystem := &cloud.FileSystem{
+					DnsName:         dnsName,
+					FileSystemId:    filesystemId,
+					StorageCapacity: storageCapacity,
+				}
+
+				ctx := context.Background()
+				mockCloud.EXPECT().DescribeFileSystem(gomock.Eq(ctx), gomock.Eq(filesystemId)).Return(filesystem, nil)
+
+				resp, err := driver.ControllerExpandVolume(ctx, req)
+				if err != nil {
+					t.Fatalf("ControllerExpandVolume failed: %v", err)
+				}
+
+				if resp.CapacityBytes != currentBytes {
+					t.Fatal("resp.CapacityBytes is not equal to currentBytes")
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "fail: required capacity greater than limit",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
+					cloud:    mockCloud,
+				}
+
+				req := &csi.ControllerExpandVolumeRequest{
+					VolumeId: filesystemId,
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: requiredBytes,
+						LimitBytes:    1,
+					},
+				}
+
+				ctx := context.Background()
+
+				_, err := driver.ControllerExpandVolume(ctx, req)
+				if err == nil {
+					t.Fatalf("ControllerExpandVolume success: %v", err)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "fail: missing volumeId",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
+					cloud:    mockCloud,
+				}
+
+				req := &csi.ControllerExpandVolumeRequest{
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: requiredBytes,
+						LimitBytes:    limitBytes,
+					},
+				}
+
+				ctx := context.Background()
+
+				_, err := driver.ControllerExpandVolume(ctx, req)
+				if err == nil {
+					t.Fatalf("ControllerExpandVolume success: %v", err)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "fail: missing capacity range",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
+					cloud:    mockCloud,
+				}
+
+				req := &csi.ControllerExpandVolumeRequest{
+					VolumeId: filesystemId,
+				}
+
+				ctx := context.Background()
+
+				_, err := driver.ControllerExpandVolume(ctx, req)
+				if err == nil {
+					t.Fatalf("ControllerExpandVolume success: %v", err)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "fail: describe throws error",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
+					cloud:    mockCloud,
+				}
+
+				req := &csi.ControllerExpandVolumeRequest{
+					VolumeId: filesystemId,
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: requiredBytes,
+						LimitBytes:    limitBytes,
+					},
+				}
+
+				ctx := context.Background()
+				mockCloud.EXPECT().DescribeFileSystem(gomock.Eq(ctx), gomock.Eq(filesystemId)).Return(nil, errors.New(""))
+
+				_, err := driver.ControllerExpandVolume(ctx, req)
+				if err == nil {
+					t.Fatalf("ControllerExpandVolume success: %v", err)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "fail: resize throws error",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
+					cloud:    mockCloud,
+				}
+
+				req := &csi.ControllerExpandVolumeRequest{
+					VolumeId: filesystemId,
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: requiredBytes,
+						LimitBytes:    limitBytes,
+					},
+				}
+				filesystem := &cloud.FileSystem{
+					DnsName:         dnsName,
+					FileSystemId:    filesystemId,
+					StorageCapacity: storageCapacity,
+				}
+
+				ctx := context.Background()
+				mockCloud.EXPECT().DescribeFileSystem(gomock.Eq(ctx), gomock.Eq(filesystemId)).Return(filesystem, nil)
+				mockCloud.EXPECT().ResizeFileSystem(gomock.Eq(ctx), gomock.Eq(filesystemId), gomock.Any()).Return(nil, errors.New(""))
+
+				_, err := driver.ControllerExpandVolume(ctx, req)
+				if err == nil {
+					t.Fatalf("ControllerExpandVolume success: %v", err)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "fail: wait throws error",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := &Driver{
+					endpoint: endpoint,
+					inFlight: internal.NewInFlight(),
+					cloud:    mockCloud,
+				}
+
+				req := &csi.ControllerExpandVolumeRequest{
+					VolumeId: filesystemId,
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: requiredBytes,
+						LimitBytes:    limitBytes,
+					},
+				}
+				filesystem := &cloud.FileSystem{
+					DnsName:         dnsName,
+					FileSystemId:    filesystemId,
+					StorageCapacity: storageCapacity,
+				}
+
+				ctx := context.Background()
+				mockCloud.EXPECT().DescribeFileSystem(gomock.Eq(ctx), gomock.Eq(filesystemId)).Return(filesystem, nil)
+				mockCloud.EXPECT().ResizeFileSystem(gomock.Eq(ctx), gomock.Eq(filesystemId), gomock.Any()).Return(&newCapacity, nil)
+				mockCloud.EXPECT().WaitForFileSystemResize(gomock.Eq(ctx), gomock.Eq(filesystemId), newCapacity).Return(errors.New(""))
+
+				_, err := driver.ControllerExpandVolume(ctx, req)
+				if err == nil {
+					t.Fatalf("ControllerExpandVolume success: %v", err)
 				}
 
 				mockCtl.Finish()

--- a/pkg/driver/mocks/mock_cloud.go
+++ b/pkg/driver/mocks/mock_cloud.go
@@ -167,6 +167,36 @@ func (mr *MockCloudMockRecorder) DescribeVolume(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolume", reflect.TypeOf((*MockCloud)(nil).DescribeVolume), arg0, arg1)
 }
 
+// ResizeFileSystem mocks base method.
+func (m *MockCloud) ResizeFileSystem(arg0 context.Context, arg1 string, arg2 int64) (*int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResizeFileSystem", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResizeFileSystem indicates an expected call of ResizeFileSystem.
+func (mr *MockCloudMockRecorder) ResizeFileSystem(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizeFileSystem", reflect.TypeOf((*MockCloud)(nil).ResizeFileSystem), arg0, arg1, arg2)
+}
+
+// ResizeVolume mocks base method.
+func (m *MockCloud) ResizeVolume(arg0 context.Context, arg1 string, arg2 int64) (*int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResizeVolume", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResizeVolume indicates an expected call of ResizeVolume.
+func (mr *MockCloudMockRecorder) ResizeVolume(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizeVolume", reflect.TypeOf((*MockCloud)(nil).ResizeVolume), arg0, arg1, arg2)
+}
+
 // WaitForFileSystemAvailable mocks base method.
 func (m *MockCloud) WaitForFileSystemAvailable(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -179,6 +209,20 @@ func (m *MockCloud) WaitForFileSystemAvailable(arg0 context.Context, arg1 string
 func (mr *MockCloudMockRecorder) WaitForFileSystemAvailable(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForFileSystemAvailable", reflect.TypeOf((*MockCloud)(nil).WaitForFileSystemAvailable), arg0, arg1)
+}
+
+// WaitForFileSystemResize mocks base method.
+func (m *MockCloud) WaitForFileSystemResize(arg0 context.Context, arg1 string, arg2 int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForFileSystemResize", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForFileSystemResize indicates an expected call of WaitForFileSystemResize.
+func (mr *MockCloudMockRecorder) WaitForFileSystemResize(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForFileSystemResize", reflect.TypeOf((*MockCloud)(nil).WaitForFileSystemResize), arg0, arg1, arg2)
 }
 
 // WaitForSnapshotAvailable mocks base method.
@@ -207,4 +251,18 @@ func (m *MockCloud) WaitForVolumeAvailable(arg0 context.Context, arg1 string) er
 func (mr *MockCloudMockRecorder) WaitForVolumeAvailable(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForVolumeAvailable", reflect.TypeOf((*MockCloud)(nil).WaitForVolumeAvailable), arg0, arg1)
+}
+
+// WaitForVolumeResize mocks base method.
+func (m *MockCloud) WaitForVolumeResize(arg0 context.Context, arg1 string, arg2 int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForVolumeResize", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForVolumeResize indicates an expected call of WaitForVolumeResize.
+func (mr *MockCloudMockRecorder) WaitForVolumeResize(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForVolumeResize", reflect.TypeOf((*MockCloud)(nil).WaitForVolumeResize), arg0, arg1, arg2)
 }


### PR DESCRIPTION
Allows users to resize the storage capacities of dynamically provisioned FSx OpenZFS filesystems and volumes