### PR TITLE
Add support for DELETE_CHILD_VOLUMES_AND_SNAPSHOTS on deletion

### DIFF
--- a/examples/kubernetes/dynamic-provisioning/filesystem/storageclass.yaml
+++ b/examples/kubernetes/dynamic-provisioning/filesystem/storageclass.yaml
@@ -8,8 +8,9 @@ parameters:
   deploymentType: "SINGLE_AZ_1" #REQUIRED
   throughputCapacity: "64" #REQUIRED
   subnetIds: "subnet-0eabfaa81fb22bcaf" #REQUIRED
-  skipFinalBackup: "true" #REQUIRED
-  kmsKey: "12345678-90ab-cdef-ghij-klmnopqrstuv"
+  skipFinalBackupOnDeletion: "true" #REQUIRED, SET ON DELETION
+  optionsOnDeletion: "[DELETE_CHILD_VOLUMES_AND_SNAPSHOTS]" #SET ON DELETION
+  kmsKeyId: "12345678-90ab-cdef-ghij-klmnopqrstuv"
   automaticBackupRetentionDays: "1"
   copyTagsToBackups: "false"
   copyTagsToVolumes: "false"

--- a/examples/kubernetes/dynamic-provisioning/volume/storageclass.yaml
+++ b/examples/kubernetes/dynamic-provisioning/volume/storageclass.yaml
@@ -13,6 +13,7 @@ parameters:
   recordSizeKiB: "128"
   userAndGroupQuotas: "[{Id=1,StorageCapacityQuotaGiB=10,Type=USER}]"
   tags: "Tag1=Value1,Tag2=Value2"
+  optionsOnDeletion: "[DELETE_CHILD_VOLUMES_AND_SNAPSHOTS]" #SET ON DELETION
 reclaimPolicy: Delete
 allowVolumeExpansion: true
 mountOptions:

--- a/pkg/cloud/mocks/mock_fsx.go
+++ b/pkg/cloud/mocks/mock_fsx.go
@@ -216,6 +216,21 @@ func (mr *MockFSxMockRecorder) DescribeVolumesWithContext(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumesWithContext", reflect.TypeOf((*MockFSx)(nil).DescribeVolumesWithContext), varargs...)
 }
 
+// ListTagsForResource mocks base method.
+func (m *MockFSx) ListTagsForResource(arg0 *fsx.ListTagsForResourceInput) (*fsx.ListTagsForResourceOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTagsForResource", arg0)
+	ret0, _ := ret[0].(*fsx.ListTagsForResourceOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTagsForResource indicates an expected call of ListTagsForResource.
+func (mr *MockFSxMockRecorder) ListTagsForResource(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResource", reflect.TypeOf((*MockFSx)(nil).ListTagsForResource), arg0)
+}
+
 // UpdateFileSystemWithContext mocks base method.
 func (m *MockFSx) UpdateFileSystemWithContext(arg0 context.Context, arg1 *fsx.UpdateFileSystemInput, arg2 ...request.Option) (*fsx.UpdateFileSystemOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -43,7 +44,6 @@ const (
 	volumeContextVolumeType                   = "volumeType"
 	volumeContextDnsName                      = "dnsName"
 	volumeContextVolumePath                   = "volumePath"
-	volumeContextSkipFinalBackup              = "skipFinalBackup"
 	volumeParamsVolumeType                    = "volumeType"
 	volumeParamsKmsKeyId                      = "kmsKeyId"
 	volumeParamsAutomaticBackupRetentionDays  = "automaticBackupRetentionDays"
@@ -58,14 +58,23 @@ const (
 	volumeParamsSecurityGroupIds              = "securityGroupIds"
 	volumeParamsSubnetIds                     = "subnetIds"
 	volumeParamsTags                          = "tags"
-	volumeParamsSkipFinalBackup               = "skipFinalBackup"
+	volumeParamsOptionsOnDeletion             = "optionsOnDeletion"
+	volumeParamsSkipFinalBackupOnDeletion     = "skipFinalBackupOnDeletion"
 	volumeParamsCopyTagsToSnapshots           = "copyTagsToSnapshots"
 	volumeParamsDataCompressionType           = "dataCompressionType"
-	volumeParamsNfsExports                    = "NfsExports"
+	volumeParamsNfsExports                    = "nfsExports"
 	volumeParamsParentVolumeId                = "parentVolumeId"
 	volumeParamsReadOnly                      = "readOnly"
 	volumeParamsRecordSizeKiB                 = "recordSizeKiB"
 	volumeParamsUserAndGroupQuotas            = "userAndGroupQuotas"
+)
+
+// The external-provisioner automatically configures reserved parameter keys on the CreateVolumeRequest:
+// https://kubernetes-csi.github.io/docs/external-provisioner.html#storageclass-parameters
+// Each of these parameter keys have the same prefix, "csi.storage.k8s.io".
+// We will store this prefix as a constant to avoid throwing an error when we encounter these parameters.
+const (
+	reservedVolumeParamsPrefix = "csi.storage.k8s.io"
 )
 
 const (
@@ -113,8 +122,8 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			return nil, status.Error(codes.InvalidArgument, "Snapshots are not available at the filesystem level. Set volumeType to volume.")
 		}
 
-		if _, ok := volumeParams[volumeParamsSkipFinalBackup]; !ok {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid parameter of %s: %s", volumeParamsSkipFinalBackup, "field required")
+		if _, ok := volumeParams[volumeParamsSkipFinalBackupOnDeletion]; !ok {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid parameter of %s: %s", volumeParamsSkipFinalBackupOnDeletion, "field required")
 		}
 
 		fsOptions := cloud.FileSystemOptions{
@@ -122,55 +131,62 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		}
 
 		for key, value := range volumeParams {
-			switch key {
-			case volumeParamsKmsKeyId:
-				fsOptions.KmsKeyId = util.StringToStringPointer(value)
-			case volumeParamsAutomaticBackupRetentionDays:
+			switch {
+			case key == volumeParamsKmsKeyId:
+				fsOptions.KmsKeyId = aws.String(value)
+			case key == volumeParamsAutomaticBackupRetentionDays:
 				i, err := util.StringToIntPointer(value)
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid parameter of %s: %s", volumeParamsAutomaticBackupRetentionDays, err)
 				}
 				fsOptions.AutomaticBackupRetentionDays = i
-			case volumeParamsCopyTagsToBackups:
+			case key == volumeParamsCopyTagsToBackups:
 				boolVal, err := util.StringToBoolPointer(value)
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid parameter of %s: %s", volumeParamsCopyTagsToBackups, err)
 				}
 				fsOptions.CopyTagsToBackups = boolVal
-			case volumeParamsCopyTagsToVolumes:
+			case key == volumeParamsCopyTagsToVolumes:
 				boolVal, err := util.StringToBoolPointer(value)
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid parameter of %s: %s", volumeParamsCopyTagsToVolumes, err)
 				}
 				fsOptions.CopyTagsToVolumes = boolVal
-			case volumeParamsDailyAutomaticBackupStartTime:
-				fsOptions.DailyAutomaticBackupStartTime = util.StringToStringPointer(value)
-			case volumeParamsDeploymentType:
-				fsOptions.DeploymentType = util.StringToStringPointer(value)
-			case volumeParamsDiskIopsConfiguration:
-				fsOptions.DiskIopsConfiguration = util.StringToStringPointer(value)
-			case volumeParamsRootVolumeConfiguration:
-				fsOptions.RootVolumeConfiguration = util.StringToStringPointer(value)
-			case volumeParamsThroughputCapacity:
+			case key == volumeParamsDailyAutomaticBackupStartTime:
+				fsOptions.DailyAutomaticBackupStartTime = aws.String(value)
+			case key == volumeParamsDeploymentType:
+				fsOptions.DeploymentType = aws.String(value)
+			case key == volumeParamsDiskIopsConfiguration:
+				fsOptions.DiskIopsConfiguration = aws.String(value)
+			case key == volumeParamsRootVolumeConfiguration:
+				fsOptions.RootVolumeConfiguration = aws.String(value)
+			case key == volumeParamsThroughputCapacity:
 				i, err := util.StringToIntPointer(value)
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid parameter of %s: %s", volumeParamsThroughputCapacity, err)
 				}
 				fsOptions.ThroughputCapacity = i
-			case volumeParamsWeeklyMaintenanceStartTime:
-				fsOptions.WeeklyMaintenanceStartTime = util.StringToStringPointer(value)
-			case volumeParamsSecurityGroupIds:
+			case key == volumeParamsWeeklyMaintenanceStartTime:
+				fsOptions.WeeklyMaintenanceStartTime = aws.String(value)
+			case key == volumeParamsSecurityGroupIds:
 				fsOptions.SecurityGroupIds = util.SplitCommasAndRemoveOuterBrackets(value)
-			case volumeParamsSubnetIds:
+			case key == volumeParamsSubnetIds:
 				fsOptions.SubnetIds = util.SplitCommasAndRemoveOuterBrackets(value)
-			case volumeParamsTags:
-				fsOptions.Tags = util.StringToStringPointer(value)
-			case volumeParamsSkipFinalBackup:
+			case key == volumeParamsTags:
+				fsOptions.Tags = aws.String(value)
+			case key == volumeParamsOptionsOnDeletion:
+				fsOptions.OptionsOnDeletion = aws.String(value)
+			case key == volumeParamsSkipFinalBackupOnDeletion:
 				boolVal, err := util.StringToBoolPointer(value)
 				if err != nil {
-					return nil, status.Errorf(codes.InvalidArgument, "invalid parameter of %s: %s", volumeParamsSkipFinalBackup, err)
+					return nil, status.Errorf(codes.InvalidArgument, "invalid parameter of %s: %s", volumeParamsSkipFinalBackupOnDeletion, err)
 				}
-				fsOptions.SkipFinalBackup = boolVal
+				fsOptions.SkipFinalBackupOnDeletion = boolVal
+			case key == volumeParamsVolumeType:
+			case strings.HasPrefix(key, reservedVolumeParamsPrefix):
+				continue
+			default:
+				return nil, status.Errorf(codes.InvalidArgument, "invalid parameter of %s: %s", key, value)
 			}
 		}
 
@@ -197,13 +213,13 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 				CapacityBytes: util.GiBToBytes(fs.StorageCapacity),
 				VolumeId:      fs.FileSystemId,
 				VolumeContext: map[string]string{
-					volumeContextDnsName:         fs.DnsName,
-					volumeContextVolumeType:      volumeType,
-					volumeContextSkipFinalBackup: volumeParams[volumeParamsSkipFinalBackup],
+					volumeContextDnsName:    fs.DnsName,
+					volumeContextVolumeType: volumeType,
 				},
 			},
 		}, nil
 	}
+
 	if volumeType == volVolumeType {
 		var snapshotArn *string
 		volumeSource := req.GetVolumeContentSource()
@@ -232,35 +248,42 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		}
 
 		for key, value := range volumeParams {
-			switch key {
-			case volumeParamsCopyTagsToSnapshots:
+			switch {
+			case key == volumeParamsCopyTagsToSnapshots:
 				boolVal, err := util.StringToBoolPointer(value)
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid parameter of %s: %s", volumeParamsCopyTagsToSnapshots, err)
 				}
 				volOptions.CopyTagsToSnapshots = boolVal
-			case volumeParamsDataCompressionType:
-				volOptions.DataCompressionType = util.StringToStringPointer(value)
-			case volumeParamsNfsExports:
-				volOptions.NfsExports = util.StringToStringPointer(value)
-			case volumeParamsParentVolumeId:
-				volOptions.ParentVolumeId = util.StringToStringPointer(value)
-			case volumeParamsReadOnly:
+			case key == volumeParamsDataCompressionType:
+				volOptions.DataCompressionType = aws.String(value)
+			case key == volumeParamsNfsExports:
+				volOptions.NfsExports = aws.String(value)
+			case key == volumeParamsParentVolumeId:
+				volOptions.ParentVolumeId = aws.String(value)
+			case key == volumeParamsReadOnly:
 				boolVal, err := util.StringToBoolPointer(value)
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid parameter of %s: %s", volumeParamsReadOnly, err)
 				}
 				volOptions.ReadOnly = boolVal
-			case volumeParamsRecordSizeKiB:
+			case key == volumeParamsRecordSizeKiB:
 				i, err := util.StringToIntPointer(value)
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid parameter of %s: %s", volumeParamsRecordSizeKiB, err)
 				}
 				volOptions.RecordSizeKiB = i
-			case volumeParamsUserAndGroupQuotas:
-				volOptions.UserAndGroupQuotas = util.StringToStringPointer(value)
-			case volumeParamsTags:
-				volOptions.Tags = util.StringToStringPointer(value)
+			case key == volumeParamsUserAndGroupQuotas:
+				volOptions.UserAndGroupQuotas = aws.String(value)
+			case key == volumeParamsTags:
+				volOptions.Tags = aws.String(value)
+			case key == volumeParamsOptionsOnDeletion:
+				volOptions.OptionsOnDeletion = aws.String(value)
+			case key == volumeParamsVolumeType:
+			case strings.HasPrefix(key, reservedVolumeParamsPrefix):
+				continue
+			default:
+				return nil, status.Errorf(codes.InvalidArgument, "invalid parameter of %s: %s", key, value)
 			}
 		}
 
@@ -558,6 +581,7 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 			NodeExpansionRequired: false,
 		}, nil
 	}
+
 	if splitVolumeId[0] == cloud.VolumePrefix {
 		v, err := d.cloud.DescribeVolume(ctx, volumeID)
 		if err != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -60,10 +60,10 @@ func SplitCommasAndRemoveOuterBrackets(input string) []string {
 		input = strings.Trim(input, "{}")
 	}
 
-	leftCurly := []int{}
-	leftSquare := []int{}
+	var leftCurly []int
+	var leftSquare []int
 
-	slices := []string{}
+	var slices []string
 	lastComma := 0
 
 	for i, c := range input {
@@ -90,7 +90,7 @@ func SplitCommasAndRemoveOuterBrackets(input string) []string {
 
 	slices = append(slices, input[lastComma:])
 
-	values := []string{}
+	var values []string
 	for _, val := range slices {
 		if strings.HasPrefix(val, "{") {
 			val = strings.Trim(val, "{}")
@@ -125,10 +125,6 @@ func GiBToBytes(volumeSizeGiB int64) int64 {
 	return volumeSizeGiB * GiB
 }
 
-func StringToStringPointer(input string) *string {
-	return &input
-}
-
 func StringToIntPointer(input string) (*int64, error) {
 	output, err := strconv.ParseInt(input, 10, 64)
 	if err != nil {
@@ -148,4 +144,13 @@ func StringToBoolPointer(input string) (*bool, error) {
 func BoolToStringPointer(input bool) *string {
 	output := strconv.FormatBool(input)
 	return &output
+}
+
+func Contains(slice []string, element string) bool {
+	for _, value := range slice {
+		if value == element {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -129,3 +129,49 @@ func TestMapValues(t *testing.T) {
 		})
 	}
 }
+
+func TestContains(t *testing.T) {
+	testCases := []struct {
+		name     string
+		slice    []string
+		element  string
+		expected bool
+	}{
+		{
+			name: "Success: element in slice",
+			slice: []string{
+				"element1",
+				"element2",
+				"element3",
+			},
+			element:  "element3",
+			expected: true,
+		},
+		{
+			name: "Success: element not in slice",
+			slice: []string{
+				"element1",
+				"element2",
+				"element3",
+			},
+			element:  "element4",
+			expected: false,
+		},
+		{
+			name:     "Success: slice is empty",
+			slice:    []string{},
+			element:  "element4",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := Contains(tc.slice, tc.element)
+
+			if actual != tc.expected {
+				t.Fatalf("Contains got wrong result. actual: %v, expected: %v", actual, tc.expected)
+			}
+		})
+	}
+}

--- a/tests/sanity/sanity_test.go
+++ b/tests/sanity/sanity_test.go
@@ -62,8 +62,8 @@ var _ = Describe("AWS FSx for OpenZFS CSI Driver", func() {
 		StagingPath:    stagePath,
 		TestVolumeSize: 2000 * util.GiB,
 		TestVolumeParameters: map[string]string{
-			"volumeType":      "filesystem",
-			"skipFinalBackup": "true",
+			"volumeType":                "filesystem",
+			"skipFinalBackupOnDeletion": "true",
 		},
 	}
 	sanity.GinkgoTest(config)


### PR DESCRIPTION
#### Context
This commit allows users to configure an ```optionsOnDelete``` parameter on the storage class when creating new Persistent Volumes via the FSx for OpenZFS CSI driver. This parameter, mapped to the OpenZFSConfiguration Options parameter in the [delete-file-system](https://docs.aws.amazon.com/cli/latest/reference/fsx/delete-file-system.html) and [delete-volume](https://docs.aws.amazon.com/cli/latest/reference/fsx/delete-volume.html) FSx APIs, allows users to specify whether they wish to delete child volumes and snapshots when deleting the OpenZFS file system or volume. Due to limitations in the CSI specification, users will only be able to configure this parameter at creation time. To change this behavior post-creation time, users will need to update the associated tags on the underlying file system or volume, outside of the Kubernetes environment.

Also: 
Fixed a few small bugs in our controller validation, unit tests, and example manifest files.
Deprecated usage of `util.StringToStringPointer` in favor of `aws.string()`

#### Testing
Deleted a PV tied to an FSx for OpenZFS file system, with and without this parameter configured. 
Deleted a PV tied to an FSx for OpenZFS child volume, with and without this parameter configured.
In all test cases, I created a child volume for the storage resource and confirmed that the deletion was successful/failed, depending on the value of the ```optionsOnDelete``` parameter.