### PR TITLE
Allow users to specify StorageCapacityReservation and StorageCapacityQuota on child volumes

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -111,11 +111,9 @@ type FileSystemOptions struct {
 
 // Volume represents an OpenZFS volume
 type Volume struct {
-	FileSystemId                  string
-	VolumeId                      string
-	StorageCapacityQuotaGiB       int64
-	StorageCapacityReservationGiB int64
-	VolumePath                    string
+	FileSystemId string
+	VolumeId     string
+	VolumePath   string
 }
 
 // VolumeOptions represents parameters to create an OpenZFS volume
@@ -541,11 +539,9 @@ func (c *cloud) CreateVolume(ctx context.Context, volumeId string, volumeOptions
 	}
 
 	return &Volume{
-		FileSystemId:                  aws.StringValue(output.Volume.FileSystemId),
-		VolumeId:                      aws.StringValue(output.Volume.VolumeId),
-		StorageCapacityQuotaGiB:       aws.Int64Value(output.Volume.OpenZFSConfiguration.StorageCapacityQuotaGiB),
-		StorageCapacityReservationGiB: aws.Int64Value(output.Volume.OpenZFSConfiguration.StorageCapacityReservationGiB),
-		VolumePath:                    aws.StringValue(output.Volume.OpenZFSConfiguration.VolumePath),
+		FileSystemId: aws.StringValue(output.Volume.FileSystemId),
+		VolumeId:     aws.StringValue(output.Volume.VolumeId),
+		VolumePath:   aws.StringValue(output.Volume.OpenZFSConfiguration.VolumePath),
 	}, nil
 }
 
@@ -634,10 +630,8 @@ func (c *cloud) DescribeVolume(ctx context.Context, volumeId string) (*Volume, e
 	}
 
 	return &Volume{
-		VolumeId:                      aws.StringValue(v.VolumeId),
-		StorageCapacityQuotaGiB:       aws.Int64Value(v.OpenZFSConfiguration.StorageCapacityQuotaGiB),
-		StorageCapacityReservationGiB: aws.Int64Value(v.OpenZFSConfiguration.StorageCapacityReservationGiB),
-		VolumePath:                    aws.StringValue(v.OpenZFSConfiguration.VolumePath),
+		VolumeId:   aws.StringValue(v.VolumeId),
+		VolumePath: aws.StringValue(v.OpenZFSConfiguration.VolumePath),
 	}, nil
 }
 

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -939,14 +939,6 @@ func TestCreateVolume(t *testing.T) {
 					t.Fatalf("FileSystemId mismatches. actual: %v expected: %v", resp.FileSystemId, dnsName)
 				}
 
-				if resp.StorageCapacityQuotaGiB != aws.Int64Value(storageCapacityQuotaGiB) {
-					t.Fatalf("StorageCapacityQuotaGiB mismatches. actual: %v expected: %v", resp.StorageCapacityQuotaGiB, storageCapacityQuotaGiB)
-				}
-
-				if resp.StorageCapacityReservationGiB != aws.Int64Value(storageCapacityReservationGiB) {
-					t.Fatalf("StorageCapacityReservationGiB mismatches. actual: %v expected: %v", resp.StorageCapacityReservationGiB, storageCapacityReservationGiB)
-				}
-
 				if resp.VolumePath != aws.StringValue(volumePath) {
 					t.Fatalf("VolumePath mismatches. actual: %v expected: %v", resp.VolumePath, volumePath)
 				}
@@ -998,14 +990,6 @@ func TestCreateVolume(t *testing.T) {
 
 				if resp.FileSystemId != aws.StringValue(fileSystemId) {
 					t.Fatalf("FileSystemId mismatches. actual: %v expected: %v", resp.FileSystemId, dnsName)
-				}
-
-				if resp.StorageCapacityQuotaGiB != aws.Int64Value(storageCapacityQuotaGiB) {
-					t.Fatalf("StorageCapacityQuotaGiB mismatches. actual: %v expected: %v", resp.StorageCapacityQuotaGiB, storageCapacityQuotaGiB)
-				}
-
-				if resp.StorageCapacityReservationGiB != aws.Int64Value(storageCapacityReservationGiB) {
-					t.Fatalf("StorageCapacityReservationGiB mismatches. actual: %v expected: %v", resp.StorageCapacityReservationGiB, storageCapacityReservationGiB)
 				}
 
 				if resp.VolumePath != aws.StringValue(volumePath) {
@@ -1060,14 +1044,6 @@ func TestCreateVolume(t *testing.T) {
 
 				if resp.FileSystemId != aws.StringValue(fileSystemId) {
 					t.Fatalf("FileSystemId mismatches. actual: %v expected: %v", resp.FileSystemId, dnsName)
-				}
-
-				if resp.StorageCapacityQuotaGiB != aws.Int64Value(storageCapacityQuotaGiB) {
-					t.Fatalf("StorageCapacityQuotaGiB mismatches. actual: %v expected: %v", resp.StorageCapacityQuotaGiB, storageCapacityQuotaGiB)
-				}
-
-				if resp.StorageCapacityReservationGiB != aws.Int64Value(storageCapacityReservationGiB) {
-					t.Fatalf("StorageCapacityReservationGiB mismatches. actual: %v expected: %v", resp.StorageCapacityReservationGiB, storageCapacityReservationGiB)
 				}
 
 				if resp.VolumePath != aws.StringValue(volumePath) {

--- a/pkg/cloud/fakes.go
+++ b/pkg/cloud/fakes.go
@@ -114,26 +114,13 @@ func (c *FakeCloudProvider) WaitForFileSystemResize(ctx context.Context, fileSys
 func (c *FakeCloudProvider) CreateVolume(ctx context.Context, volumeName string, volumeOptions VolumeOptions) (*Volume, error) {
 	v, exists := c.volumes[volumeName]
 	if exists {
-		if v.StorageCapacityReservationGiB == *volumeOptions.StorageCapacityReservationGiB {
-			return v, nil
-		} else {
-			return nil, ErrAlreadyExists
-		}
-	}
-
-	var storageCapacity int64
-	if volumeOptions.StorageCapacityQuotaGiB == nil {
-		storageCapacity = 10
-	} else {
-		storageCapacity = *volumeOptions.StorageCapacityQuotaGiB
+		return v, nil
 	}
 
 	v = &Volume{
-		FileSystemId:                  "fs-1234",
-		StorageCapacityQuotaGiB:       storageCapacity,
-		StorageCapacityReservationGiB: storageCapacity,
-		VolumePath:                    "/",
-		VolumeId:                      fmt.Sprintf("fsvol-%d", random.Uint64()),
+		FileSystemId: "fs-1234",
+		VolumePath:   "/",
+		VolumeId:     fmt.Sprintf("fsvol-%d", random.Uint64()),
 	}
 	c.volumes[volumeName] = v
 	return v, nil
@@ -142,8 +129,6 @@ func (c *FakeCloudProvider) CreateVolume(ctx context.Context, volumeName string,
 func (c *FakeCloudProvider) ResizeVolume(ctx context.Context, volumeId string, newSizeGiB int64) (*int64, error) {
 	for _, v := range c.volumes {
 		if v.VolumeId == volumeId {
-			v.StorageCapacityQuotaGiB = newSizeGiB
-			v.StorageCapacityReservationGiB = newSizeGiB
 			return &newSizeGiB, nil
 		}
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -27,7 +27,8 @@ import (
 )
 
 const (
-	GiB = 1024 * 1024 * 1024
+	GiB                            = 1024 * 1024 * 1024
+	DefaultVolumeStorageRequestGiB = 1
 )
 
 func ParseEndpoint(endpoint string) (string, string, error) {


### PR DESCRIPTION
This commit:
* Revises the strategy for allocating the StorageCapacityReservation and StorageCapacityQuota when dynamically provisioning child volumes. These parameters can now be specified in the storage class. Previously, both of these values were set to the requested storage on the PVC.
* When dynamically provisioning a child volume, a user must now specify EXACTLY 1GiB in the storage request of the PVC. This is enforced to ensure that users are aware they will not receive the storage they request via the PVC.
* As a consequence of this strategy, we are no longer allowing users to expand volume for child volumes. If they attempt to do so, the RPC will perform a no-op and return success.
* Documentation updates will be featured in a separate PR. This is to accommodate a series of general improvements I made to the documentation which are out of scope of this specific change.

Testing:
Performed E2E testing by running through every example in our example usage files. These files required several changes, see this PR for these revisions: https://github.com/kubernetes-sigs/aws-fsx-openzfs-csi-driver/pull/12