### PR TITLE
Adopt Kubernetes recommended labels

### DIFF
--- a/charts/aws-fsx-openzfs-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-fsx-openzfs-csi-driver/templates/_helpers.tpl
@@ -49,7 +49,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Common selector labels
 */}}
 {{- define "aws-fsx-openzfs-csi-driver.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "aws-fsx-openzfs-csi-driver.name" . }}
+app.kubernetes.io/part-of: {{ include "aws-fsx-openzfs-csi-driver.name" . }}
 {{- if ne .Release.Name "kustomize" }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/aws-fsx-openzfs-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-fsx-openzfs-csi-driver/templates/controller-deployment.yaml
@@ -12,12 +12,12 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: fsx-openzfs-csi-controller
+      app.kubernetes.io/name: fsx-openzfs-csi-controller
       {{- include "aws-fsx-openzfs-csi-driver.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: fsx-openzfs-csi-controller
+        app.kubernetes.io/name: fsx-openzfs-csi-controller
         {{- include "aws-fsx-openzfs-csi-driver.labels" . | nindent 8 }}
         {{- if .Values.controller.podLabels }}
         {{- toYaml .Values.controller.podLabels | nindent 8 }}

--- a/charts/aws-fsx-openzfs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-fsx-openzfs-csi-driver/templates/node-daemonset.yaml
@@ -5,18 +5,19 @@ metadata:
   name: fsx-openzfs-csi-node
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/name: fsx-openzfs-csi-node
     {{- include "aws-fsx-openzfs-csi-driver.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: fsx-openzfs-csi-node
+      app.kubernetes.io/name: fsx-openzfs-csi-node
       {{- include "aws-fsx-openzfs-csi-driver.selectorLabels" . | nindent 6 }}
   updateStrategy:
     {{- toYaml .Values.node.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:
-        app: fsx-openzfs-csi-node
+        app.kubernetes.io/name: fsx-openzfs-csi-node
         {{- include "aws-fsx-openzfs-csi-driver.labels" . | nindent 8 }}
         {{- if .Values.node.podLabels }}
         {{- toYaml .Values.node.podLabels | nindent 8 }}

--- a/charts/aws-fsx-openzfs-csi-driver/templates/poddisruptionbudget-controller.yaml
+++ b/charts/aws-fsx-openzfs-csi-driver/templates/poddisruptionbudget-controller.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: fsx-openzfs-csi-controller
+      app.kubernetes.io/name: fsx-openzfs-csi-controller
       {{- include "aws-fsx-openzfs-csi-driver.selectorLabels" . | nindent 6 }}
   {{- if le (.Values.controller.replicaCount | int) 2 }}
   maxUnavailable: 1

--- a/charts/aws-fsx-openzfs-csi-driver/values.yaml
+++ b/charts/aws-fsx-openzfs-csi-driver/values.yaml
@@ -103,7 +103,7 @@ controller:
         - podAffinityTerm:
             labelSelector:
               matchExpressions:
-                - key: app
+                - key: app.kubernetes.io/name
                   operator: In
                   values:
                     - fsx-openzfs-csi-controller

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 metadata:
   name: fsx-openzfs-csi-controller
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
 spec:
   replicas: 2
   strategy:
@@ -14,13 +14,13 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: fsx-openzfs-csi-controller
-      app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+      app.kubernetes.io/name: fsx-openzfs-csi-controller
+      app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
   template:
     metadata:
       labels:
-        app: fsx-openzfs-csi-controller
-        app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+        app.kubernetes.io/name: fsx-openzfs-csi-controller
+        app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
     spec:
       nodeSelector:
         kubernetes.io/os: linux
@@ -41,7 +41,7 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchExpressions:
-                - key: app
+                - key: app.kubernetes.io/name
                   operator: In
                   values:
                   - fsx-openzfs-csi-controller

--- a/deploy/kubernetes/base/controller-serviceaccount.yaml
+++ b/deploy/kubernetes/base/controller-serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: fsx-openzfs-csi-controller-sa
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
 ---
 # Source: aws-fsx-openzfs-csi-driver/templates/controller-serviceaccount.yaml
 kind: ClusterRole
@@ -13,7 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: fsx-openzfs-csi-external-provisioner-role
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
 rules:
   # The following rule should be uncommented for plugins that require secrets
   # for provisioning.
@@ -54,7 +54,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: fsx-openzfs-csi-external-resizer-role
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
 rules:
   # The following rule should be uncommented for plugins that require secrets
   # for provisioning.
@@ -86,7 +86,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: fsx-openzfs-csi-external-snapshotter-role
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
 rules:
   - apiGroups: [ "" ]
     resources: [ "events" ]
@@ -112,7 +112,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: fsx-openzfs-csi-external-provisioner-binding
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
 subjects:
   - kind: ServiceAccount
     name: fsx-openzfs-csi-controller-sa
@@ -127,7 +127,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: fsx-openzfs-csi-external-resizer-binding
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
 subjects:
   - kind: ServiceAccount
     name: fsx-openzfs-csi-controller-sa
@@ -142,7 +142,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: fsx-openzfs-csi-external-snapshotter-binding
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
 subjects:
   - kind: ServiceAccount
     name: fsx-openzfs-csi-controller-sa

--- a/deploy/kubernetes/base/csidriver.yaml
+++ b/deploy/kubernetes/base/csidriver.yaml
@@ -5,7 +5,7 @@ kind: CSIDriver
 metadata:
   name: fsx.openzfs.csi.aws.com
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
 spec:
   attachRequired: false
   podInfoOnMount: false

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -6,12 +6,13 @@ apiVersion: apps/v1
 metadata:
   name: fsx-openzfs-csi-node
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/name: fsx-openzfs-csi-node
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
 spec:
   selector:
     matchLabels:
-      app: fsx-openzfs-csi-node
-      app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+      app.kubernetes.io/name: fsx-openzfs-csi-node
+      app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%
@@ -19,8 +20,8 @@ spec:
   template:
     metadata:
       labels:
-        app: fsx-openzfs-csi-node
-        app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+        app.kubernetes.io/name: fsx-openzfs-csi-node
+        app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
     spec:
       affinity:
         nodeAffinity:

--- a/deploy/kubernetes/base/node-serviceaccount.yaml
+++ b/deploy/kubernetes/base/node-serviceaccount.yaml
@@ -5,4 +5,4 @@ kind: ServiceAccount
 metadata:
   name: fsx-openzfs-csi-node-sa
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver

--- a/deploy/kubernetes/base/poddisruptionbudget-controller.yaml
+++ b/deploy/kubernetes/base/poddisruptionbudget-controller.yaml
@@ -5,10 +5,10 @@ kind: PodDisruptionBudget
 metadata:
   name: fsx-openzfs-csi-controller
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
 spec:
   selector:
     matchLabels:
-      app: fsx-openzfs-csi-controller
-      app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+      app.kubernetes.io/name: fsx-openzfs-csi-controller
+      app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
   maxUnavailable: 1

--- a/docs/install.md
+++ b/docs/install.md
@@ -107,5 +107,5 @@ Review the [configuration values](https://github.com/kubernetes-sigs/aws-fsx-ope
 
 #### Once the driver has been deployed, verify the pods are running:
 ```sh
-kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-fsx-openzfs-csi-driver
+kubectl get pods -n kube-system -l app.kubernetes.io/part-of=aws-fsx-openzfs-csi-driver
 ```


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Chore/consistency fix.

**What is this PR about? / Why do we need it?**
Addresses #28 by replacing our `app` labels with `app.kubernetes.io/name`. 
Further replaces our usage of `app.kubernetes.io/name` with `app.kubernetes.io/part-of`
See https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/ for the list of Kubernetes recommended labels.

**What testing is done?** 
Deployed the driver to my cluster and verified that the driver still worked.