### PR TITLE
Fix Snapshot Parameters Bug

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -108,6 +108,9 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	}
 
 	volumeParams := req.GetParameters()
+	if volumeParams == nil {
+		volumeParams = make(map[string]string)
+	}
 
 	deleteReservedParameters(volumeParams)
 
@@ -402,7 +405,10 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 	}
 	defer d.inFlight.Delete(req.GetName())
 
-	snapshotParams := req.Parameters
+	snapshotParams := req.GetParameters()
+	if snapshotParams == nil {
+		snapshotParams = make(map[string]string)
+	}
 
 	deleteReservedParameters(snapshotParams)
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**
Fixes a bug where users could not create a snapshot without specifying parameters.

Issue: https://github.com/kubernetes-sigs/aws-fsx-openzfs-csi-driver/issues/27

**What testing is done?** 
Unit test