### PR TITLE
Add support for setting hostNetwork on the node daemonset

### DIFF
--- a/charts/aws-fsx-openzfs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-fsx-openzfs-csi-driver/templates/node-daemonset.yaml
@@ -171,6 +171,7 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      hostNetwork: {{ .Values.node.hostNetwork }}
       dnsPolicy: {{ .Values.node.dnsPolicy }}
       {{- with .Values.node.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}

--- a/charts/aws-fsx-openzfs-csi-driver/values.yaml
+++ b/charts/aws-fsx-openzfs-csi-driver/values.yaml
@@ -176,6 +176,7 @@ node:
                 operator: NotIn
                 values:
                   - fargate
+  hostNetwork: false
   dnsPolicy: ClusterFirst
   dnsConfig: {}
   # Example config which uses the AWS nameservers

--- a/deploy/kubernetes/base/clusterrole-csi-node.yaml
+++ b/deploy/kubernetes/base/clusterrole-csi-node.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: fsx-openzfs-csi-node-role
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
 rules:
   - apiGroups: [""]
     resources: ["nodes"]

--- a/deploy/kubernetes/base/clusterrolebinding-csi-node.yaml
+++ b/deploy/kubernetes/base/clusterrolebinding-csi-node.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: fsx-openzfs-csi-node-getter-binding
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
 subjects:
   - kind: ServiceAccount
     name: fsx-openzfs-csi-node-sa

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -127,6 +127,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+      hostNetwork: false
       dnsPolicy: ClusterFirst
       volumes:
         - name: kubelet-dir


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature

**What is this PR about? / Why do we need it?**
This PR adds support to the helm chart for setting hostNetwork in the pod spec of the node daemonset. When running an EKS cluster with Cilium as the CNI in overlay mode, the daemonset pods fail to mount AWS FSx volumes unless the pod runs with `hostNetwork: true`

**What testing is done?** 
The default values in this PR result in no changes to the current behavior (since the current value for hostNetwork is an implicit `false`). Setting hostNetwork to `true` has been tested on AWS EKS running Cilium in overlay mode, resulting in successful mounting of AWS FSx volumes on the nodes.
