### PR TITLE
Make hostNetwork configurable on node daemonset

### DIFF
--- a/charts/aws-fsx-openzfs-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-fsx-openzfs-csi-driver/templates/node-daemonset.yaml
@@ -171,6 +171,7 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      hostNetwork: {{ .Values.node.hostNetwork }}
       dnsPolicy: {{ .Values.node.dnsPolicy }}
       {{- with .Values.node.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}

--- a/charts/aws-fsx-openzfs-csi-driver/values.yaml
+++ b/charts/aws-fsx-openzfs-csi-driver/values.yaml
@@ -176,6 +176,7 @@ node:
                 operator: NotIn
                 values:
                   - fargate
+  hostNetwork: false
   dnsPolicy: ClusterFirst
   dnsConfig: {}
   # Example config which uses the AWS nameservers

--- a/deploy/kubernetes/base/clusterrole-csi-node.yaml
+++ b/deploy/kubernetes/base/clusterrole-csi-node.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: fsx-openzfs-csi-node-role
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
 rules:
   - apiGroups: [""]
     resources: ["nodes"]

--- a/deploy/kubernetes/base/clusterrolebinding-csi-node.yaml
+++ b/deploy/kubernetes/base/clusterrolebinding-csi-node.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: fsx-openzfs-csi-node-getter-binding
   labels:
-    app.kubernetes.io/name: aws-fsx-openzfs-csi-driver
+    app.kubernetes.io/part-of: aws-fsx-openzfs-csi-driver
 subjects:
   - kind: ServiceAccount
     name: fsx-openzfs-csi-node-sa

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -127,6 +127,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+      hostNetwork: false
       dnsPolicy: ClusterFirst
       volumes:
         - name: kubelet-dir

--- a/docs/install.md
+++ b/docs/install.md
@@ -96,6 +96,8 @@ EKS Managed Node Groups support automatically tainting nodes, see [here](https:/
 ### Deploy driver
 You may deploy the FSx for OpenZFS CSI driver via Kustomize or Helm
 
+*Note: When using custom [CNI Plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/) (e.g. Cilium) you might have to enable host networking for mounting the filesystem successfully.*
+
 #### Kustomize
 ```sh
 kubectl apply -k "github.com/kubernetes-sigs/aws-fsx-openzfs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.1"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Feature

**What is this PR about? / Why do we need it?**
This is required to support custom CNIs (such as Cilium) where the IPs are not allocated from the VPC CIDR block.

**What testing is done?**
Successfully mounting fsx volumes while using Cilium CNI and hostNetwork=true

Supersedes https://github.com/kubernetes-sigs/aws-fsx-openzfs-csi-driver/pull/62