### PR TITLE
Implement NodeGetVolumeStats for kubelet volume metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.25.3
 	github.com/onsi/gomega v1.38.2
 	github.com/spf13/pflag v1.0.10
+	golang.org/x/sys v0.36.0
 	google.golang.org/grpc v1.75.1
 	google.golang.org/protobuf v1.36.9
 	k8s.io/api v0.34.1
@@ -114,7 +115,6 @@ require (
 	golang.org/x/net v0.44.0 // indirect
 	golang.org/x/oauth2 v0.31.0 // indirect
 	golang.org/x/sync v0.17.0 // indirect
-	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/term v0.35.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
 	golang.org/x/time v0.13.0 // indirect

--- a/pkg/driver/mocks/mock_mount.go
+++ b/pkg/driver/mocks/mock_mount.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	unix "golang.org/x/sys/unix"
 	mount "k8s.io/mount-utils"
 )
 
@@ -46,6 +47,21 @@ func (m *MockMounter) CanSafelySkipMountPointCheck() bool {
 func (mr *MockMounterMockRecorder) CanSafelySkipMountPointCheck() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanSafelySkipMountPointCheck", reflect.TypeOf((*MockMounter)(nil).CanSafelySkipMountPointCheck))
+}
+
+// GetStatfs mocks base method.
+func (m *MockMounter) GetStatfs(arg0 string) (*unix.Statfs_t, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStatfs", arg0)
+	ret0, _ := ret[0].(*unix.Statfs_t)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStatfs indicates an expected call of GetStatfs.
+func (mr *MockMounterMockRecorder) GetStatfs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStatfs", reflect.TypeOf((*MockMounter)(nil).GetStatfs), arg0)
 }
 
 // GetMountRefs mocks base method.

--- a/pkg/driver/mount.go
+++ b/pkg/driver/mount.go
@@ -16,8 +16,10 @@ limitations under the License.
 package driver
 
 import (
-	"k8s.io/mount-utils"
 	"os"
+
+	"golang.org/x/sys/unix"
+	"k8s.io/mount-utils"
 )
 
 // Mounter is an interface for mount operations
@@ -26,6 +28,7 @@ type Mounter interface {
 	IsCorruptedMnt(err error) bool
 	PathExists(path string) (bool, error)
 	MakeDir(pathname string) error
+	GetStatfs(path string) (*unix.Statfs_t, error)
 }
 
 type NodeMounter struct {
@@ -60,4 +63,13 @@ func (m *NodeMounter) PathExists(path string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// GetStatfs returns filesystem statistics for the given path.
+func (m *NodeMounter) GetStatfs(path string) (*unix.Statfs_t, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		return nil, err
+	}
+	return &stat, nil
 }

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -38,7 +38,9 @@ const (
 )
 
 var (
-	nodeCaps = []csi.NodeServiceCapability_RPC_Type{}
+	nodeCaps = []csi.NodeServiceCapability_RPC_Type{
+		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
+	}
 )
 
 type nodeService struct {
@@ -248,7 +250,57 @@ func (d *nodeService) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 }
 
 func (d *nodeService) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
+	klog.V(4).InfoS("NodeGetVolumeStats: called with", "args", *req)
+
+	volumeID := req.GetVolumeId()
+	if len(volumeID) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "NodeGetVolumeStats: Volume ID not provided")
+	}
+
+	volumePath := req.GetVolumePath()
+	if len(volumePath) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "NodeGetVolumeStats: Volume path not provided")
+	}
+
+	exists, err := d.mounter.PathExists(volumePath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "NodeGetVolumeStats: failed to check if path %s exists: %v", volumePath, err)
+	}
+	if !exists {
+		return nil, status.Errorf(codes.NotFound, "NodeGetVolumeStats: volume path %s does not exist", volumePath)
+	}
+
+	statfs, err := d.mounter.GetStatfs(volumePath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "NodeGetVolumeStats: failed to statfs on %s: %v", volumePath, err)
+	}
+
+	availableBytes := int64(statfs.Bavail) * int64(statfs.Bsize)
+	totalBytes := int64(statfs.Blocks) * int64(statfs.Bsize)
+	usedBytes := (int64(statfs.Blocks) - int64(statfs.Bfree)) * int64(statfs.Bsize)
+
+	usage := []*csi.VolumeUsage{
+		{
+			Unit:      csi.VolumeUsage_BYTES,
+			Available: availableBytes,
+			Total:     totalBytes,
+			Used:      usedBytes,
+		},
+	}
+
+	totalInodes := int64(statfs.Files)
+	if totalInodes > 0 {
+		freeInodes := int64(statfs.Ffree)
+		usedInodes := totalInodes - freeInodes
+		usage = append(usage, &csi.VolumeUsage{
+			Unit:      csi.VolumeUsage_INODES,
+			Available: freeInodes,
+			Total:     totalInodes,
+			Used:      usedInodes,
+		})
+	}
+
+	return &csi.NodeGetVolumeStatsResponse{Usage: usage}, nil
 }
 
 func (d *nodeService) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -18,18 +18,19 @@ package driver
 import (
 	"context"
 	"fmt"
-	"github.com/kubernetes-sigs/aws-fsx-openzfs-csi-driver/pkg/driver/internal"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 	"reflect"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
+	"golang.org/x/sys/unix"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 
 	cloudMock "github.com/kubernetes-sigs/aws-fsx-openzfs-csi-driver/pkg/cloud/mocks"
+	"github.com/kubernetes-sigs/aws-fsx-openzfs-csi-driver/pkg/driver/internal"
 	driverMocks "github.com/kubernetes-sigs/aws-fsx-openzfs-csi-driver/pkg/driver/mocks"
 )
 
@@ -816,6 +817,271 @@ func TestNodeUnpublishVolume(t *testing.T) {
 			},
 		},
 	}
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.testFunc)
+	}
+}
+
+func TestNodeGetVolumeStats(t *testing.T) {
+	var (
+		volumeId   = "fsvol-0efb292807cc770ff"
+		volumePath = "/target/path"
+	)
+
+	testCases := []struct {
+		name     string
+		testFunc func(t *testing.T)
+	}{
+		{
+			name: "success: returns bytes and inode usage",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMetadata := cloudMock.NewMockMetadataService(mockCtl)
+				mockMounter := driverMocks.NewMockMounter(mockCtl)
+
+				driver := &nodeService{
+					metadata: mockMetadata,
+					mounter:  mockMounter,
+					inFlight: internal.NewInFlight(),
+				}
+
+				ctx := context.Background()
+				req := &csi.NodeGetVolumeStatsRequest{
+					VolumeId:   volumeId,
+					VolumePath: volumePath,
+				}
+
+				mockMounter.EXPECT().PathExists(gomock.Eq(volumePath)).Return(true, nil)
+				mockMounter.EXPECT().GetStatfs(gomock.Eq(volumePath)).Return(&unix.Statfs_t{
+					Bsize:  4096,
+					Blocks: 262144, // 1 GiB total
+					Bfree:  131072, // 512 MiB free
+					Bavail: 131072, // 512 MiB available
+					Files:  65536,
+					Ffree:  32768,
+				}, nil)
+
+				resp, err := driver.NodeGetVolumeStats(ctx, req)
+				if err != nil {
+					t.Fatalf("NodeGetVolumeStats failed: %v", err)
+				}
+
+				if len(resp.Usage) != 2 {
+					t.Fatalf("Expected 2 usage entries (bytes + inodes), got %d", len(resp.Usage))
+				}
+
+				// Check bytes usage
+				bytesUsage := resp.Usage[0]
+				if bytesUsage.Unit != csi.VolumeUsage_BYTES {
+					t.Fatalf("Expected BYTES unit, got %v", bytesUsage.Unit)
+				}
+				expectedTotal := int64(262144) * int64(4096)
+				expectedUsed := (int64(262144) - int64(131072)) * int64(4096)
+				expectedAvail := int64(131072) * int64(4096)
+				if bytesUsage.Total != expectedTotal {
+					t.Fatalf("Expected total %d, got %d", expectedTotal, bytesUsage.Total)
+				}
+				if bytesUsage.Used != expectedUsed {
+					t.Fatalf("Expected used %d, got %d", expectedUsed, bytesUsage.Used)
+				}
+				if bytesUsage.Available != expectedAvail {
+					t.Fatalf("Expected available %d, got %d", expectedAvail, bytesUsage.Available)
+				}
+
+				// Check inode usage
+				inodeUsage := resp.Usage[1]
+				if inodeUsage.Unit != csi.VolumeUsage_INODES {
+					t.Fatalf("Expected INODES unit, got %v", inodeUsage.Unit)
+				}
+				if inodeUsage.Total != 65536 {
+					t.Fatalf("Expected total inodes 65536, got %d", inodeUsage.Total)
+				}
+				if inodeUsage.Available != 32768 {
+					t.Fatalf("Expected available inodes 32768, got %d", inodeUsage.Available)
+				}
+				if inodeUsage.Used != 32768 {
+					t.Fatalf("Expected used inodes 32768, got %d", inodeUsage.Used)
+				}
+			},
+		},
+		{
+			name: "success: no inode entry when Files is zero",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMetadata := cloudMock.NewMockMetadataService(mockCtl)
+				mockMounter := driverMocks.NewMockMounter(mockCtl)
+
+				driver := &nodeService{
+					metadata: mockMetadata,
+					mounter:  mockMounter,
+					inFlight: internal.NewInFlight(),
+				}
+
+				ctx := context.Background()
+				req := &csi.NodeGetVolumeStatsRequest{
+					VolumeId:   volumeId,
+					VolumePath: volumePath,
+				}
+
+				mockMounter.EXPECT().PathExists(gomock.Eq(volumePath)).Return(true, nil)
+				mockMounter.EXPECT().GetStatfs(gomock.Eq(volumePath)).Return(&unix.Statfs_t{
+					Bsize:  4096,
+					Blocks: 262144,
+					Bfree:  131072,
+					Bavail: 131072,
+					Files:  0,
+					Ffree:  0,
+				}, nil)
+
+				resp, err := driver.NodeGetVolumeStats(ctx, req)
+				if err != nil {
+					t.Fatalf("NodeGetVolumeStats failed: %v", err)
+				}
+
+				if len(resp.Usage) != 1 {
+					t.Fatalf("Expected 1 usage entry (bytes only), got %d", len(resp.Usage))
+				}
+				if resp.Usage[0].Unit != csi.VolumeUsage_BYTES {
+					t.Fatalf("Expected BYTES unit, got %v", resp.Usage[0].Unit)
+				}
+			},
+		},
+		{
+			name: "fail: missing volume ID",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMetadata := cloudMock.NewMockMetadataService(mockCtl)
+				mockMounter := driverMocks.NewMockMounter(mockCtl)
+
+				driver := &nodeService{
+					metadata: mockMetadata,
+					mounter:  mockMounter,
+					inFlight: internal.NewInFlight(),
+				}
+
+				ctx := context.Background()
+				req := &csi.NodeGetVolumeStatsRequest{
+					VolumePath: volumePath,
+				}
+
+				_, err := driver.NodeGetVolumeStats(ctx, req)
+				expectErr(t, err, codes.InvalidArgument)
+			},
+		},
+		{
+			name: "fail: missing volume path",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMetadata := cloudMock.NewMockMetadataService(mockCtl)
+				mockMounter := driverMocks.NewMockMounter(mockCtl)
+
+				driver := &nodeService{
+					metadata: mockMetadata,
+					mounter:  mockMounter,
+					inFlight: internal.NewInFlight(),
+				}
+
+				ctx := context.Background()
+				req := &csi.NodeGetVolumeStatsRequest{
+					VolumeId: volumeId,
+				}
+
+				_, err := driver.NodeGetVolumeStats(ctx, req)
+				expectErr(t, err, codes.InvalidArgument)
+			},
+		},
+		{
+			name: "fail: volume path does not exist",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMetadata := cloudMock.NewMockMetadataService(mockCtl)
+				mockMounter := driverMocks.NewMockMounter(mockCtl)
+
+				driver := &nodeService{
+					metadata: mockMetadata,
+					mounter:  mockMounter,
+					inFlight: internal.NewInFlight(),
+				}
+
+				ctx := context.Background()
+				req := &csi.NodeGetVolumeStatsRequest{
+					VolumeId:   volumeId,
+					VolumePath: volumePath,
+				}
+
+				mockMounter.EXPECT().PathExists(gomock.Eq(volumePath)).Return(false, nil)
+
+				_, err := driver.NodeGetVolumeStats(ctx, req)
+				expectErr(t, err, codes.NotFound)
+			},
+		},
+		{
+			name: "fail: PathExists returns error",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMetadata := cloudMock.NewMockMetadataService(mockCtl)
+				mockMounter := driverMocks.NewMockMounter(mockCtl)
+
+				driver := &nodeService{
+					metadata: mockMetadata,
+					mounter:  mockMounter,
+					inFlight: internal.NewInFlight(),
+				}
+
+				ctx := context.Background()
+				req := &csi.NodeGetVolumeStatsRequest{
+					VolumeId:   volumeId,
+					VolumePath: volumePath,
+				}
+
+				mockMounter.EXPECT().PathExists(gomock.Eq(volumePath)).Return(false, fmt.Errorf("permission denied"))
+
+				_, err := driver.NodeGetVolumeStats(ctx, req)
+				expectErr(t, err, codes.Internal)
+			},
+		},
+		{
+			name: "fail: statfs returns error",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMetadata := cloudMock.NewMockMetadataService(mockCtl)
+				mockMounter := driverMocks.NewMockMounter(mockCtl)
+
+				driver := &nodeService{
+					metadata: mockMetadata,
+					mounter:  mockMounter,
+					inFlight: internal.NewInFlight(),
+				}
+
+				ctx := context.Background()
+				req := &csi.NodeGetVolumeStatsRequest{
+					VolumeId:   volumeId,
+					VolumePath: volumePath,
+				}
+
+				mockMounter.EXPECT().PathExists(gomock.Eq(volumePath)).Return(true, nil)
+				mockMounter.EXPECT().GetStatfs(gomock.Eq(volumePath)).Return(nil, fmt.Errorf("statfs failed"))
+
+				_, err := driver.NodeGetVolumeStats(ctx, req)
+				expectErr(t, err, codes.Internal)
+			},
+		},
+	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, tc.testFunc)
 	}


### PR DESCRIPTION
Add GET_VOLUME_STATS node capability and implement NodeGetVolumeStats using statfs(). This enables kubelet to report kubelet_volume_stats_* Prometheus metrics (used_bytes, capacity_bytes, available_bytes, inodes) for FSx OpenZFS volumes.

The implementation uses a direct statfs() call on the NFS mount path, which issues a lightweight NFS STATFS RPC to the FSx server. This is appropriate for FSx OpenZFS because volumes have bounded capacity via ZFS quotas, so statfs returns meaningful results instantly (unlike EFS which requires expensive filesystem walks).

Changes:
- Add GetStatfs method to Mounter interface for testability
- Implement NodeGetVolumeStats with volume ID/path validation
- Advertise GET_VOLUME_STATS in NodeGetCapabilities
- Add 7 test cases covering success and error paths

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

**What testing is done?** 
