### PR TITLE
Revert "Add Volume deletion validation"

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -19,10 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"strings"
-	"time"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/fsx"
@@ -30,6 +26,9 @@ import (
 	"github.com/kubernetes-sigs/aws-fsx-openzfs-csi-driver/pkg/util"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
+	"os"
+	"strings"
+	"time"
 )
 
 // Polling
@@ -103,13 +102,11 @@ type Cloud interface {
 	DeleteFileSystem(ctx context.Context, parameters map[string]string) error
 	DescribeFileSystem(ctx context.Context, fileSystemId string) (*FileSystem, error)
 	WaitForFileSystemAvailable(ctx context.Context, fileSystemId string) error
-	WaitForFileSystemDeletion(ctx context.Context, fileSystemId string) error
 	WaitForFileSystemResize(ctx context.Context, fileSystemId string, resizeGiB int32) error
 	CreateVolume(ctx context.Context, parameters map[string]string) (*Volume, error)
 	DeleteVolume(ctx context.Context, parameters map[string]string) error
 	DescribeVolume(ctx context.Context, volumeId string) (*Volume, error)
 	WaitForVolumeAvailable(ctx context.Context, volumeId string) error
-	WaitForVolumeDeletion(ctx context.Context, volumeId string) error
 	WaitForVolumeResize(ctx context.Context, volumeId string, resizeGiB int32) error
 	CreateSnapshot(ctx context.Context, options map[string]string) (*Snapshot, error)
 	DeleteSnapshot(ctx context.Context, parameters map[string]string) error
@@ -245,21 +242,6 @@ func (c *cloud) WaitForFileSystemAvailable(ctx context.Context, fileSystemId str
 	return err
 }
 
-func (c *cloud) WaitForFileSystemDeletion(ctx context.Context, fileSystemId string) error {
-	err := wait.PollUntilContextTimeout(ctx, PollCheckInterval, PollCheckTimeout, true, func(ctx context.Context) (done bool, err error) {
-		_, err = c.getFileSystem(ctx, fileSystemId)
-		if err == ErrNotFound {
-			return true, nil
-		} else if err != nil {
-			return true, err
-		}
-		klog.V(2).InfoS("WaitForFileSystemDeletion", "filesystem", fileSystemId)
-		return false, nil
-	})
-
-	return err
-}
-
 func (c *cloud) WaitForFileSystemResize(ctx context.Context, fileSystemId string, resizeGiB int32) error {
 	err := wait.Poll(PollCheckInterval, PollCheckTimeout, func() (done bool, err error) {
 		updateAction, err := c.getUpdateResizeFilesystemAdministrativeAction(ctx, fileSystemId, resizeGiB)
@@ -353,21 +335,6 @@ func (c *cloud) WaitForVolumeAvailable(ctx context.Context, volumeId string) err
 		default:
 			return true, fmt.Errorf("unexpected state for volume %s: %q", volumeId, v.Lifecycle)
 		}
-	})
-
-	return err
-}
-
-func (c *cloud) WaitForVolumeDeletion(ctx context.Context, volumeId string) error {
-	err := wait.PollUntilContextTimeout(ctx, PollCheckInterval, PollCheckTimeout, true, func(ctx context.Context) (done bool, err error) {
-		_, err = c.getVolume(ctx, volumeId)
-		if err == ErrNotFound {
-			return true, nil
-		} else if err != nil {
-			return true, err
-		}
-		klog.V(2).InfoS("WaitForVolumeDeletion", "volume", volumeId)
-		return false, nil
 	})
 
 	return err

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -18,17 +18,16 @@ package cloud
 import (
 	"context"
 	"errors"
-	"reflect"
-	"strconv"
-	"testing"
-	"time"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/fsx"
 	"github.com/aws/aws-sdk-go-v2/service/fsx/types"
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/aws-fsx-openzfs-csi-driver/pkg/cloud/mocks"
 	"github.com/kubernetes-sigs/aws-fsx-openzfs-csi-driver/pkg/util"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
 )
 
 func TestCreateFileSystem(t *testing.T) {
@@ -595,57 +594,6 @@ func TestWaitForFileSystemAvailable(t *testing.T) {
 	}
 }
 
-func TestWaitForFileSystemDeletion(t *testing.T) {
-	fileSystemId := "fs-123456789abcdefgh"
-	testCases := []struct {
-		name     string
-		testFunc func(t *testing.T)
-	}{
-		{
-			name: "success: DescribeFileSystems return not found",
-			testFunc: func(t *testing.T) {
-				mockCtl := gomock.NewController(t)
-				mockFSx := mocks.NewMockFSx(mockCtl)
-				c := &cloud{
-					fsx: mockFSx,
-				}
-
-				ctx := context.Background()
-				mockFSx.EXPECT().DescribeFileSystems(gomock.Any(), gomock.Any()).Return(nil, ErrNotFound)
-				err := c.WaitForFileSystemDeletion(ctx, fileSystemId)
-				if err != nil {
-					t.Fatalf("WaitForFileSystemDeletion is failed: %v", err)
-				}
-
-				mockCtl.Finish()
-			},
-		},
-		{
-			name: "fail: DescribeFileSystems return other error",
-			testFunc: func(t *testing.T) {
-				mockCtl := gomock.NewController(t)
-				mockFSx := mocks.NewMockFSx(mockCtl)
-				c := &cloud{
-					fsx: mockFSx,
-				}
-
-				ctx := context.Background()
-				mockFSx.EXPECT().DescribeFileSystems(gomock.Any(), gomock.Any()).Return(nil, errors.New(""))
-				err := c.WaitForFileSystemDeletion(ctx, fileSystemId)
-				if err == nil {
-					t.Fatalf("WaitForFileSystemDeletion is not failed: %v", err)
-				}
-
-				mockCtl.Finish()
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, tc.testFunc)
-	}
-}
-
 func TestWaitForFileSystemResize(t *testing.T) {
 	var (
 		filesystemId       = "fs-1234"
@@ -1189,58 +1137,6 @@ func TestWaitForVolumeAvailable(t *testing.T) {
 				err := c.WaitForVolumeAvailable(ctx, volumeId)
 				if err == nil {
 					t.Fatal("WaitForVolumeAvailable is not failed")
-				}
-
-				mockCtl.Finish()
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, tc.testFunc)
-	}
-}
-
-func TestWaitForVolumeDeletion(t *testing.T) {
-	volumeId := "fsvol-0987654321abcdefg"
-
-	testCases := []struct {
-		name     string
-		testFunc func(t *testing.T)
-	}{
-		{
-			name: "success: DescribeVolumes return empty",
-			testFunc: func(t *testing.T) {
-				mockCtl := gomock.NewController(t)
-				mockFSx := mocks.NewMockFSx(mockCtl)
-				c := &cloud{
-					fsx: mockFSx,
-				}
-
-				ctx := context.Background()
-				mockFSx.EXPECT().DescribeVolumes(gomock.Any(), gomock.Any()).Return(nil, ErrNotFound)
-				err := c.WaitForVolumeDeletion(ctx, volumeId)
-				if err != nil {
-					t.Fatalf("WaitForVolumeDeletion is failed: %v", err)
-				}
-
-				mockCtl.Finish()
-			},
-		},
-		{
-			name: "fail: DescribeVolumes return other error",
-			testFunc: func(t *testing.T) {
-				mockCtl := gomock.NewController(t)
-				mockFSx := mocks.NewMockFSx(mockCtl)
-				c := &cloud{
-					fsx: mockFSx,
-				}
-
-				ctx := context.Background()
-				mockFSx.EXPECT().DescribeVolumes(gomock.Any(), gomock.Any()).Return(nil, errors.New(""))
-				err := c.WaitForVolumeDeletion(ctx, volumeId)
-				if err == nil {
-					t.Fatalf("WaitForVolumeDeletion is not failed: %v", err)
 				}
 
 				mockCtl.Finish()

--- a/pkg/cloud/fakes.go
+++ b/pkg/cloud/fakes.go
@@ -18,13 +18,12 @@ package cloud
 import (
 	"context"
 	"fmt"
+	"github.com/aws/aws-sdk-go-v2/service/fsx/types"
 	"math/rand"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/aws/aws-sdk-go-v2/service/fsx/types"
 )
 
 var random *rand.Rand
@@ -118,14 +117,8 @@ func (c *FakeCloudProvider) ResizeFileSystem(ctx context.Context, fileSystemId s
 }
 
 func (c *FakeCloudProvider) DeleteFileSystem(ctx context.Context, parameters map[string]string) error {
-	// parameters["FileSystemId"] in Sanity test is JSON string, eg: "\"fs-1234\""
-	// While actual id is "fs-1234"
-	// For backward compatibility, we can remove both the JSON string and the unquote string
-	unquoteId := strings.Trim(parameters["FileSystemId"], "\"")
 	delete(c.fileSystems, parameters["FileSystemId"])
-	delete(c.fileSystems, unquoteId)
 	delete(c.fileSystemsParameters, parameters["FileSystemId"])
-	delete(c.fileSystemsParameters, unquoteId)
 	return nil
 }
 
@@ -139,10 +132,6 @@ func (c *FakeCloudProvider) DescribeFileSystem(ctx context.Context, filesystemId
 }
 
 func (c *FakeCloudProvider) WaitForFileSystemAvailable(ctx context.Context, fileSystemId string) error {
-	return nil
-}
-
-func (c *FakeCloudProvider) WaitForFileSystemDeletion(ctx context.Context, fileSystemId string) error {
 	return nil
 }
 
@@ -182,14 +171,8 @@ func (c *FakeCloudProvider) CreateVolume(ctx context.Context, parameters map[str
 }
 
 func (c *FakeCloudProvider) DeleteVolume(ctx context.Context, parameters map[string]string) (err error) {
-	// parameters["VolumeId"] in Sanity test is JSON string, eg: "\"fsvol-1234\""
-	// While actual id is "fsvol-1234"
-	// For backward compatibility, we can remove both the JSON string and the unquote string
-	unquoteId := strings.Trim(parameters["VolumeId"], "\"")
 	delete(c.volumes, parameters["VolumeId"])
-	delete(c.volumes, unquoteId)
 	delete(c.volumesParameters, parameters["VolumeId"])
-	delete(c.volumesParameters, unquoteId)
 	return nil
 }
 
@@ -203,10 +186,6 @@ func (c *FakeCloudProvider) DescribeVolume(ctx context.Context, volumeId string)
 }
 
 func (c *FakeCloudProvider) WaitForVolumeAvailable(ctx context.Context, volumeId string) error {
-	return nil
-}
-
-func (c *FakeCloudProvider) WaitForVolumeDeletion(ctx context.Context, volumeId string) error {
 	return nil
 }
 

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -19,10 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"strconv"
-	"strings"
-
 	"github.com/aws/aws-sdk-go-v2/service/fsx/types"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/aws-fsx-openzfs-csi-driver/pkg/cloud"
@@ -32,6 +28,9 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/klog/v2"
+	"os"
+	"strconv"
+	"strings"
 )
 
 var (
@@ -370,18 +369,6 @@ func (d *controllerService) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 		return nil, status.Errorf(codes.Internal, "Could not delete volume ID %q: %v", volumeID, err)
 	}
 
-	switch splitVolumeId[0] {
-	case cloud.FilesystemPrefix:
-		err = d.cloud.WaitForFileSystemDeletion(ctx, volumeID)
-	case cloud.VolumePrefix:
-		err = d.cloud.WaitForVolumeDeletion(ctx, volumeID)
-	}
-
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not delete volume ID %q: %v", volumeID, err)
-	}
-
-	klog.V(4).InfoS("DeleteVolume: volume not found, returning with success", "volumeId", volumeID)
 	return &csi.DeleteVolumeResponse{}, nil
 }
 

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -18,9 +18,6 @@ package driver
 import (
 	"context"
 	"errors"
-	"testing"
-	"time"
-
 	"github.com/aws/aws-sdk-go-v2/service/fsx/types"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
@@ -29,6 +26,8 @@ import (
 	"github.com/kubernetes-sigs/aws-fsx-openzfs-csi-driver/pkg/driver/mocks"
 	"github.com/kubernetes-sigs/aws-fsx-openzfs-csi-driver/pkg/util"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"testing"
+	"time"
 )
 
 func TestCreateVolume(t *testing.T) {
@@ -1029,7 +1028,6 @@ func TestDeleteVolume(t *testing.T) {
 				ctx := context.Background()
 				mockCloud.EXPECT().GetDeleteParameters(gomock.Eq(ctx), gomock.Any()).Return(filesystemParameters, nil)
 				mockCloud.EXPECT().DeleteFileSystem(gomock.Eq(ctx), gomock.Any()).Return(nil)
-				mockCloud.EXPECT().WaitForFileSystemDeletion(gomock.Eq(ctx), gomock.Any()).Return(nil)
 
 				_, err := driver.DeleteVolume(ctx, req)
 				if err != nil {
@@ -1058,7 +1056,6 @@ func TestDeleteVolume(t *testing.T) {
 				ctx := context.Background()
 				mockCloud.EXPECT().GetDeleteParameters(gomock.Eq(ctx), gomock.Any()).Return(map[string]string{}, nil)
 				mockCloud.EXPECT().DeleteFileSystem(gomock.Eq(ctx), gomock.Any()).Return(nil)
-				mockCloud.EXPECT().WaitForFileSystemDeletion(gomock.Eq(ctx), gomock.Any()).Return(nil)
 
 				_, err := driver.DeleteVolume(ctx, req)
 				if err != nil {
@@ -1087,7 +1084,6 @@ func TestDeleteVolume(t *testing.T) {
 				ctx := context.Background()
 				mockCloud.EXPECT().GetDeleteParameters(gomock.Eq(ctx), gomock.Any()).Return(volumeParameters, nil)
 				mockCloud.EXPECT().DeleteVolume(gomock.Eq(ctx), gomock.Any()).Return(nil)
-				mockCloud.EXPECT().WaitForVolumeDeletion(gomock.Eq(ctx), gomock.Any()).Return(nil)
 
 				_, err := driver.DeleteVolume(ctx, req)
 				if err != nil {
@@ -1116,7 +1112,6 @@ func TestDeleteVolume(t *testing.T) {
 				ctx := context.Background()
 				mockCloud.EXPECT().GetDeleteParameters(gomock.Eq(ctx), gomock.Any()).Return(map[string]string{}, nil)
 				mockCloud.EXPECT().DeleteVolume(gomock.Eq(ctx), gomock.Any()).Return(nil)
-				mockCloud.EXPECT().WaitForVolumeDeletion(gomock.Eq(ctx), gomock.Any()).Return(nil)
 
 				_, err := driver.DeleteVolume(ctx, req)
 				if err != nil {
@@ -1210,35 +1205,6 @@ func TestDeleteVolume(t *testing.T) {
 			},
 		},
 		{
-			name: "fail: WaitForFileSystemDeletion returns error",
-			testFunc: func(t *testing.T) {
-				mockCtl := gomock.NewController(t)
-				mockCloud := mocks.NewMockCloud(mockCtl)
-
-				driver := controllerService{
-					cloud:         mockCloud,
-					inFlight:      internal.NewInFlight(),
-					driverOptions: &DriverOptions{},
-				}
-
-				req := &csi.DeleteVolumeRequest{
-					VolumeId: fileSystemId,
-				}
-
-				ctx := context.Background()
-				mockCloud.EXPECT().GetDeleteParameters(gomock.Eq(ctx), gomock.Any()).Return(volumeParameters, nil)
-				mockCloud.EXPECT().DeleteFileSystem(gomock.Eq(ctx), gomock.Any()).Return(nil)
-				mockCloud.EXPECT().WaitForFileSystemDeletion(gomock.Eq(ctx), gomock.Any()).Return(errors.New(""))
-
-				_, err := driver.DeleteVolume(ctx, req)
-				if err == nil {
-					t.Fatal("DeleteVolume is not failed")
-				}
-
-				mockCtl.Finish()
-			},
-		},
-		{
 			name: "success: DeleteVolume returns ErrNotFound",
 			testFunc: func(t *testing.T) {
 				mockCtl := gomock.NewController(t)
@@ -1285,35 +1251,6 @@ func TestDeleteVolume(t *testing.T) {
 				ctx := context.Background()
 				mockCloud.EXPECT().GetDeleteParameters(gomock.Eq(ctx), gomock.Any()).Return(volumeParameters, nil)
 				mockCloud.EXPECT().DeleteVolume(gomock.Eq(ctx), gomock.Any()).Return(errors.New(""))
-
-				_, err := driver.DeleteVolume(ctx, req)
-				if err == nil {
-					t.Fatal("DeleteVolume is not failed")
-				}
-
-				mockCtl.Finish()
-			},
-		},
-		{
-			name: "fail: WaitForVolumeDeletion returns error",
-			testFunc: func(t *testing.T) {
-				mockCtl := gomock.NewController(t)
-				mockCloud := mocks.NewMockCloud(mockCtl)
-
-				driver := controllerService{
-					cloud:         mockCloud,
-					inFlight:      internal.NewInFlight(),
-					driverOptions: &DriverOptions{},
-				}
-
-				req := &csi.DeleteVolumeRequest{
-					VolumeId: volumeId,
-				}
-
-				ctx := context.Background()
-				mockCloud.EXPECT().GetDeleteParameters(gomock.Eq(ctx), gomock.Any()).Return(volumeParameters, nil)
-				mockCloud.EXPECT().DeleteVolume(gomock.Eq(ctx), gomock.Any()).Return(nil)
-				mockCloud.EXPECT().WaitForVolumeDeletion(gomock.Eq(ctx), gomock.Any()).Return(errors.New(""))
 
 				_, err := driver.DeleteVolume(ctx, req)
 				if err == nil {

--- a/pkg/driver/mocks/mock_cloud.go
+++ b/pkg/driver/mocks/mock_cloud.go
@@ -226,20 +226,6 @@ func (mr *MockCloudMockRecorder) WaitForFileSystemAvailable(arg0, arg1 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForFileSystemAvailable", reflect.TypeOf((*MockCloud)(nil).WaitForFileSystemAvailable), arg0, arg1)
 }
 
-// WaitForFileSystemDeletion mocks base method.
-func (m *MockCloud) WaitForFileSystemDeletion(arg0 context.Context, arg1 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForFileSystemDeletion", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// WaitForFileSystemDeletion indicates an expected call of WaitForFileSystemDeletion.
-func (mr *MockCloudMockRecorder) WaitForFileSystemDeletion(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForFileSystemDeletion", reflect.TypeOf((*MockCloud)(nil).WaitForFileSystemDeletion), arg0, arg1)
-}
-
 // WaitForFileSystemResize mocks base method.
 func (m *MockCloud) WaitForFileSystemResize(arg0 context.Context, arg1 string, arg2 int32) error {
 	m.ctrl.T.Helper()
@@ -280,20 +266,6 @@ func (m *MockCloud) WaitForVolumeAvailable(arg0 context.Context, arg1 string) er
 func (mr *MockCloudMockRecorder) WaitForVolumeAvailable(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForVolumeAvailable", reflect.TypeOf((*MockCloud)(nil).WaitForVolumeAvailable), arg0, arg1)
-}
-
-// WaitForVolumeDeletion mocks base method.
-func (m *MockCloud) WaitForVolumeDeletion(arg0 context.Context, arg1 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForVolumeDeletion", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// WaitForVolumeDeletion indicates an expected call of WaitForVolumeDeletion.
-func (mr *MockCloudMockRecorder) WaitForVolumeDeletion(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForVolumeDeletion", reflect.TypeOf((*MockCloud)(nil).WaitForVolumeDeletion), arg0, arg1)
 }
 
 // WaitForVolumeResize mocks base method.


### PR DESCRIPTION
This reverts commit 2c42912eaacd3e1c2bc19e4a73bdb7dab9b134a4.

This was causing e2e tests to fail. We'll revisit adding this commit at a later date.
