### PR TITLE
Fix node in-flight lock to key on volumeID + targetPath

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -111,12 +111,22 @@ func (d *nodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume: Volume capability not supported")
 	}
 
-	if ok := d.inFlight.Insert(volumeID); !ok {
+	targetPath := req.GetTargetPath()
+	if len(targetPath) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume: Target path not provided")
+	}
+
+	// A single FSx for OpenZFS file system/volume can be mounted by multiple pods on the
+	// same node (e.g. ReadWriteMany), each at a distinct target path. Key the in-flight
+	// lock on volumeID+targetPath so concurrent operations for different pods do not
+	// collide and return Aborted.
+	inFlightKey := volumeID + targetPath
+	if ok := d.inFlight.Insert(inFlightKey); !ok {
 		return nil, status.Errorf(codes.Aborted, internal.VolumeOperationAlreadyExistsErrorMsg, volumeID)
 	}
 	defer func() {
-		klog.V(4).InfoS("NodePublishVolume: volume operation finished", "volumeId", volumeID)
-		d.inFlight.Delete(volumeID)
+		klog.V(4).InfoS("NodePublishVolume: volume operation finished", "volumeId", volumeID, "targetPath", targetPath)
+		d.inFlight.Delete(inFlightKey)
 	}()
 
 	context := req.GetVolumeContext()
@@ -149,11 +159,6 @@ func (d *nodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 
 	source := fmt.Sprintf("%s:%s", dnsName, volumePath)
-
-	targetPath := req.GetTargetPath()
-	if len(targetPath) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume: Target path not provided")
-	}
 
 	mountOptions := []string{}
 	if req.GetReadonly() {
@@ -219,12 +224,13 @@ func (d *nodeService) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 		return nil, status.Error(codes.InvalidArgument, "NodeUnpublishVolume: Target path not provided")
 	}
 
-	if ok := d.inFlight.Insert(volumeID); !ok {
+	inFlightKey := volumeID + targetPath
+	if ok := d.inFlight.Insert(inFlightKey); !ok {
 		return nil, status.Errorf(codes.Aborted, internal.VolumeOperationAlreadyExistsErrorMsg, volumeID)
 	}
 	defer func() {
-		klog.V(4).InfoS("NodeUnpublishVolume: volume operation finished", "volumeId", volumeID)
-		d.inFlight.Delete(volumeID)
+		klog.V(4).InfoS("NodeUnpublishVolume: volume operation finished", "volumeId", volumeID, "targetPath", targetPath)
+		d.inFlight.Delete(inFlightKey)
 	}()
 
 	// Check if the target is mounted before unmounting

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -651,7 +651,7 @@ func TestNodePublishVolume(t *testing.T) {
 					TargetPath:       targetPath,
 				}
 
-				driver.inFlight.Insert(volumeId)
+				driver.inFlight.Insert(volumeId + targetPath)
 
 				_, err := driver.NodePublishVolume(ctx, req)
 				expectErr(t, err, codes.Aborted)
@@ -812,10 +812,45 @@ func TestNodeUnpublishVolume(t *testing.T) {
 					TargetPath: targetPath,
 				}
 
-				driver.inFlight.Insert(volumeId)
+				driver.inFlight.Insert(volumeId + targetPath)
 
 				_, err := driver.NodeUnpublishVolume(ctx, req)
 				expectErr(t, err, codes.Aborted)
+			},
+		},
+		{
+			name: "success: same volume different target path not blocked",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMetadata := cloudMock.NewMockMetadataService(mockCtl)
+				mockMounter := driverMocks.NewMockMounter(mockCtl)
+
+				driver := &nodeService{
+					metadata: mockMetadata,
+					mounter:  mockMounter,
+					inFlight: internal.NewInFlight(),
+				}
+
+				ctx := context.Background()
+				otherTargetPath := "/target/path-other"
+				req := &csi.NodeUnpublishVolumeRequest{
+					VolumeId:   volumeId,
+					TargetPath: targetPath,
+				}
+
+				// Another pod's operation on the same volume but a different target
+				// path is in-flight; this must not block this request.
+				driver.inFlight.Insert(volumeId + otherTargetPath)
+
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(targetPath)).Return(false, nil)
+				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).Return(nil)
+
+				_, err := driver.NodeUnpublishVolume(ctx, req)
+				if err != nil {
+					t.Fatalf("NodeUnpublishVolume is failed: %v", err)
+				}
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Node `NodePublishVolume` / `NodeUnpublishVolume` previously keyed the in-flight lock solely on the volume ID (added in `87f630e "Add inflight checks to node mounting operations"`).

Because FSx for OpenZFS is NFS and a single file system/volume can be mounted by multiple pods on the **same node** (e.g. `ReadWriteMany`) at distinct target paths, concurrent node publish/unpublish calls for different pods collide on that one key and return:

```
rpc error: code = Aborted desc = An operation with the given volume <id> already exists
```

This serializes unrelated pods sharing a volume and, in practice, leaves pods stuck `Terminating` (kubelet retries `NodeUnpublishVolume` and keeps getting `Aborted`).

This change keys the node-level in-flight lock on `volumeID + targetPath`, so operations for different pods sharing the same volume no longer block one another. The target-path fetch in `NodePublishVolume` is moved above the in-flight check (it was previously fetched later). The user-facing error message is unchanged.

This mirrors the approach used by other NFS/RWX AWS CSI drivers (e.g. the EFS CSI driver keys node operations on volume + target path).

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/driver/...`
- [x] Updated existing in-flight "Aborted" tests for `NodePublishVolume` / `NodeUnpublishVolume` to seed the new composite key
- [x] Added regression test `TestNodeUnpublishVolume/success: same volume different target path not blocked`, which seeds an in-flight entry for the same volume at a different target path and asserts the unpublish still succeeds

Made with [Cursor](https://cursor.com)