### PR TITLE
Release 1.3.2 part 2/3: helm and kustomize

### DIFF
--- a/charts/aws-fsx-openzfs-csi-driver/CHANGELOG.md
+++ b/charts/aws-fsx-openzfs-csi-driver/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Helm chart
+# v1.3.2
+* Use driver v1.3.2
+* Update Go dependencies to fix CVEs
+
 # v1.3.0
 * Use driver v1.3.0
 * Add retries when attemping to remove taint

--- a/charts/aws-fsx-openzfs-csi-driver/Chart.yaml
+++ b/charts/aws-fsx-openzfs-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.3.0
+appVersion: 1.3.2
 name: aws-fsx-openzfs-csi-driver
 description: A Helm chart for the AWS FSx for OpenZFS CSI Driver
-version: 1.3.0
+version: 1.3.2
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-fsx-openzfs-csi-driver
 sources:

--- a/charts/aws-fsx-openzfs-csi-driver/values.yaml
+++ b/charts/aws-fsx-openzfs-csi-driver/values.yaml
@@ -5,7 +5,7 @@
 image:
   repository: public.ecr.aws/fsx-csi-driver/aws-fsx-openzfs-csi-driver
   # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
-  tag: v1.3.0
+  tag: v1.3.2
   pullPolicy: IfNotPresent
 
 csidriver:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -60,7 +60,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: fsx-openzfs-plugin
-          image: public.ecr.aws/fsx-csi-driver/aws-fsx-openzfs-csi-driver:v1.3.0
+          image: public.ecr.aws/fsx-csi-driver/aws-fsx-openzfs-csi-driver:v1.3.2
           imagePullPolicy: IfNotPresent
           args:
             - --mode=controller

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -45,7 +45,7 @@ spec:
         runAsUser: 0
       containers:
         - name: fsx-openzfs-plugin
-          image: public.ecr.aws/fsx-csi-driver/aws-fsx-openzfs-csi-driver:v1.3.0
+          image: public.ecr.aws/fsx-csi-driver/aws-fsx-openzfs-csi-driver:v1.3.2
           imagePullPolicy: IfNotPresent
           args:
             - --mode=node


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Neither — release chore (post-release manifest bump).


**What is this PR about? / Why do we need it?**

Post-release commit for v1.3.2. Now that the v1.3.2 image is published to ECR Public, this updates the Helm chart and kustomize base manifests to reference it:

- charts/aws-fsx-openzfs-csi-driver/Chart.yaml: appVersion and version → 1.3.2
- charts/aws-fsx-openzfs-csi-driver/values.yaml: image tag → v1.3.2
- charts/aws-fsx-openzfs-csi-driver/CHANGELOG.md: v1.3.2 entry
- deploy/kubernetes/base/{controller-deployment,node-daemonset}.yaml: driver image → v1.3.2

**What testing is done?** 

- v1.3.2 image confirmed available on ECR Public repo
- make generate-kustomize produces no diff against the hand-edited base manifests
- grype scan of the published v1.3.2 image reports no fixable vulnerabilities at any severity.
